### PR TITLE
Update phone number validation to only allow digits

### DIFF
--- a/src/components/ContactForm.jsx
+++ b/src/components/ContactForm.jsx
@@ -49,9 +49,9 @@ const ContactFormContent = () => {
         }
         break;
       case 'phoneNumber':
-        // USA format: (xxx) xxx-xxxx or xxx-xxx-xxxx
-        if (!/^\(\d{3}\)\s?\d{3}-\d{4}$|^\d{3}-\d{3}-\d{4}$/.test(value)) {
-          errorMsg = 'Use format (XXX) XXX-XXXX or XXX-XXX-XXXX';
+        // Only allow numbers (digits)
+        if (!/^\d+$/.test(value)) {
+          errorMsg = 'Only numbers are allowed';
         }
         break;
       default:
@@ -323,9 +323,9 @@ const ContactFormContentPreview = () => {
         }
         break;
       case 'phoneNumber':
-        // USA format: (xxx) xxx-xxxx or xxx-xxx-xxxx
-        if (!/^\(\d{3}\)\s?\d{3}-\d{4}$|^\d{3}-\d{3}-\d{4}$/.test(value)) {
-          errorMsg = 'Use format (XXX) XXX-XXXX or XXX-XXX-XXXX';
+        // Only allow numbers (digits)
+        if (!/^\d+$/.test(value)) {
+          errorMsg = 'Only numbers are allowed';
         }
         break;
       default:


### PR DESCRIPTION
- Replace complex US format validation with simple numeric validation
- Change regex from format-specific to digits-only: /^\d+$/
- Update error message to 'Only numbers are allowed'
- Apply changes to both main and preview form components