### PR TITLE
Update phone number placeholder to English

### DIFF
--- a/src/components/ContactForm.jsx
+++ b/src/components/ContactForm.jsx
@@ -223,7 +223,7 @@ const ContactFormContent = () => {
                     type="tel"
                     id="phoneNumber"
                     name="phoneNumber"
-                    placeholder="(123) 456-7890"
+                    placeholder="Enter your phone number"
                     value={formData.phoneNumber}
                     onChange={handleChange}
                     required
@@ -452,7 +452,7 @@ const ContactFormContentPreview = () => {
                     type="tel"
                     id="phoneNumber"
                     name="phoneNumber"
-                    placeholder="(123) 456-7890"
+                    placeholder="Enter your phone number"
                     value={formData.phoneNumber}
                     onChange={handleChange}
                     required


### PR DESCRIPTION
- Change placeholder from format example to descriptive instruction
- Replace '(123) 456-7890' with 'Enter your phone number'
- Apply changes to both main and preview form components
- Maintain consistency with English language standards